### PR TITLE
#2 sを入力したときの挙動を修正する。

### DIFF
--- a/app/executor.go
+++ b/app/executor.go
@@ -31,7 +31,9 @@ func ExecuteApp() {
 
 	grid := tview.NewGrid().SetSize(10, 2, 0, 0)
 
-	searchInputField := component.CreateSearchInputText(eventChannel)
+	app := tview.NewApplication()
+
+	searchInputField := component.CreateSearchInputText(app, eventChannel)
 	table := component.CreateTable(eventChannel)
 	description := component.CreateDescription()
 	preview := component.CreatePreview()
@@ -41,15 +43,23 @@ func ExecuteApp() {
 	grid.AddItem(description, 0, 1, 2, 2, 0, 0, false)
 	grid.AddItem(preview.TextView, 2, 1, 10, 2, 0, 0, false)
 
-	app := tview.NewApplication()
-
 	go table.EventReceiver(app, eventChannel)
 	go preview.EventReceiver(app, eventChannel)
 
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == constant.KeyUp || event.Key() == constant.KeyDown {
 			app.SetFocus(table.Table)
-			return event
+		}
+
+		// So, We need to make another way to update input text, when input-area is already focused.
+		if event.Rune() == 's' {
+			_, ok := app.GetFocus().(*tview.InputField)
+			if ok {
+				return event
+			} else {
+				app.SetFocus(searchInputField)
+				return nil
+			}
 		}
 		return event
 	})

--- a/component/search-input-text.go
+++ b/component/search-input-text.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateSearchInputText は検索の箱を作成する。
-func CreateSearchInputText(eventChannel model.EventChannel) *tview.InputField {
+func CreateSearchInputText(app *tview.Application, eventChannel model.EventChannel) *tview.InputField {
 	searchInputField := tview.NewInputField()
 	searchInputField.SetLabel("search: ")
 	searchInputField.SetBorder(true)


### PR DESCRIPTION
1. sを入力したら入力エリアにフォーカスを充てる。

2. すでに入力エリアにフォーカスが当たっていたら通常通り入力させる。